### PR TITLE
Provide accessible data

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,27 +64,21 @@ provided by `redux-falcor`. This should feel familiar to `react-redux`.
 ```js
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { reduxFalcor } from 'redux-falcor';
+import { reduxFalcor, updateFalcorCache } from 'redux-falcor';
 import App from './App';
 
 class AppContainer extends Component {
-  fetchFalcorDeps() {
-    return this.props.falcor.get(
-      ['currentUser', App.queries.user()],
-    );
-  }
 
   handleClick(event) {
     event.preventDefault();
-
-    this.props.falcor.call(['some', 'path']).then(() => {
-      console.log('Some path called');
-    }).catch(() => {
-      console.error('Some path failed');
+    this.props.getData().catch(() => {
+      console.error('Some path failed')
     });
   }
 
   render() {
+    const { falcor } = this.props;
+    console.log(falcor.getCache());
     return (
       <App
         handleClick={this.handleClick.bind(this)}
@@ -99,27 +93,66 @@ function mapStateToProps(state) {
     currentUser: state.falcor.currentUser || {}
   };
 }
+function mapDispatchToProps(dispatch, props) {
+  return {
+    getData(){
+      const { falcor } = props;
+      return falcor.call(['some', 'path']).then(() => {
+        return dispatch(updateFalcorCache(falcor.getCache()));
+      });
+    }
+  };
+}
 
-export default connect(
-  mapStateToProps,
-)(reduxFalcor(AppContainer));
+export default reduxFalcor()(connect(mapStateToProps)(AppContainer));
+
+/**
+ * Example with decorators
+ */
+@reduxFalcor()
+@connect((state) => ({
+  currentUser: state.falcor.currentUser || {}
+}), (dispatch, props) => ({
+  getData(){
+    const { falcor } = props
+    return falcor.call(['some', 'path']).then(() => {
+      return dispatch(updateFalcorCache(falcor.getCache()));
+    });
+  }  
+})
+export default class AppContainer extends Component {
+
+  handleClick(event) {
+    event.preventDefault();
+    this.props.getData().catch(() => {
+      console.error('Some path failed')
+    });
+  }
+
+  render() {
+    const { falcor } = this.props;
+    console.log(falcor.getCache());
+    return (
+      <App
+        handleClick={this.handleClick.bind(this)}
+        currentUser={this.props.currentUser}
+      />
+    );
+  }
+}
 ```
 
-You can see `reduxFalcor` has done two things for us. First off, our falcor
-model has been provided to our Component via the `falcor` prop. This is useful
-for creating event handlers that call out to our `falcor-router`.
-
-Secondly, if we define the method `fetchFalcorDeps`, `redux-falcor` will
-automatically call that function when the component is first mounted to the DOM
-as well as whenever the falcor cache has been invalidated. This method should
-return a promise that fetches all of our falcor dependencies for this
-component.
+You can see `reduxFalcor` has provided our falcor model to the component via the `falcor` prop.
+This is useful for calling our `falcor-router` which provides the data to dispatch `updateFalcorCache` actions.
+Its values can then directly accessed from the falcor cache which keeps them in sync with the store.
 
 **Warning**
 
 Because falcor is intrinsically asynchronous your code can not rely on any one
 piece of state being present when rendering. In the example above we give
 a default for `currentUser` when we haven't fetched that piece of data yet.
+To solve this issue its best to load the data before and pass them as props.
+For example checkout [redial](https://github.com/markdalgleish/redial).
 
 ### Thanks
 

--- a/src/components/createStore.js
+++ b/src/components/createStore.js
@@ -1,4 +1,4 @@
-import { update } from './duck';
+import { updateFalcorCache } from './duck';
 
 export default function createStore(reduxStore) {
   const listeners = [];
@@ -17,7 +17,7 @@ export default function createStore(reduxStore) {
 
   function trigger(cache) {
     // Update the redux with the changes
-    reduxStore.dispatch(update(cache));
+    reduxStore.dispatch(updateFalcorCache(cache));
 
     // Trigger listeners to refetch possible invalidated data
     listeners.slice().forEach((listener) => listener());

--- a/src/components/duck.js
+++ b/src/components/duck.js
@@ -9,9 +9,9 @@ export default function reduxFalcorReducer(state = {}, action) {
   }
 }
 
-export function update(falcorCache) {
+export function updateFalcorCache(falcorCache) {
   return {
     type: UPDATE,
-    payload: falcorCache,
+    payload: falcorCache
   };
 }

--- a/src/components/reduxFalcor.js
+++ b/src/components/reduxFalcor.js
@@ -8,76 +8,79 @@ function getDisplayName(WrappedComponent) {
 
 function noop() {}
 
-export default function reduxFalcor(WrappedComponent) {
-  class ReduxFalcor extends Component {
-    constructor(props, context) {
-      super(props, context);
+export default function reduxFalcor() {
 
-      this.falcor = props.falcor || context.falcor;
-      this.falcorStore = props.falcorStore || context.falcorStore;
+  return function wrapWithFalcor (WrappedComponent) {
+    class ReduxFalcor extends Component {
+      constructor(props, context) {
+        super(props, context);
 
-      invariant(this.falcorStore,
-        `Could not find "falcorStore" in either the context or ` +
-        `props of "${this.constructor.displayName}". ` +
-        `Either wrap the root component in a <FalcorProvider>, ` +
-        `or explicitly pass "falcorStore" as a prop to "${this.constructor.displayName}".`
-      );
-    }
+        this.falcor = props.falcor || context.falcor;
+        this.falcorStore = props.falcorStore || context.falcorStore;
 
-    componentDidMount() {
-      this.trySubscribe();
-    }
+        invariant(this.falcorStore,
+          `Could not find "falcorStore" in either the context or ` +
+          `props of "${this.constructor.displayName}". ` +
+          `Either wrap the root component in a <FalcorProvider>, ` +
+          `or explicitly pass "falcorStore" as a prop to "${this.constructor.displayName}".`
+        );
+      }
 
-    componentWillUnmount() {
-      this.tryUnsubscribe();
-    }
+      componentDidMount() {
+        this.trySubscribe();
+      }
 
-    trySubscribe() {
-      if (!this.unsubscribe) {
-        this.unsubscribe = this.falcorStore.subscribe(::this.handleChange);
-        this.handleChange();
+      componentWillUnmount() {
+        this.tryUnsubscribe();
+      }
+
+      trySubscribe() {
+        if (!this.unsubscribe) {
+          this.unsubscribe = this.falcorStore.subscribe(::this.handleChange);
+          this.handleChange();
+        }
+      }
+
+      handleChange() {
+        const { wrappedInstance } = this.refs;
+
+        if (!this.unsubscribe) return;
+        if (!(typeof wrappedInstance.fetchFalcorDeps === 'function')) return;
+
+        wrappedInstance.fetchFalcorDeps().then(noop);
+      }
+
+      tryUnsubscribe() {
+        if (this.unsubscribe) {
+          this.unsubscribe();
+          this.unsubscribe = null;
+        }
+      }
+
+      render() {
+        return (
+          <WrappedComponent
+            {...this.props}
+            falcor={this.falcor}
+            ref="wrappedInstance"
+          />
+        );
       }
     }
 
-    handleChange() {
-      const { wrappedInstance } = this.refs;
+    ReduxFalcor.displayName = `ReduxFalcor(${getDisplayName(WrappedComponent)})`;
+    ReduxFalcor.WrappedComponent = WrappedComponent;
 
-      if (!this.unsubscribe) return;
-      if (!(typeof wrappedInstance.fetchFalcorDeps === 'function')) return;
+    ReduxFalcor.propTypes = {
+      falcorStore: PropTypes.object,
+      falcor: PropTypes.object,
+    };
 
-      wrappedInstance.fetchFalcorDeps().then(noop);
-    }
+    ReduxFalcor.contextTypes = {
+      falcorStore: PropTypes.object.isRequired,
+      falcor: PropTypes.object.isRequired,
+    };
 
-    tryUnsubscribe() {
-      if (this.unsubscribe) {
-        this.unsubscribe();
-        this.unsubscribe = null;
-      }
-    }
-
-    render() {
-      return (
-        <WrappedComponent
-          {...this.props}
-          falcor={this.falcor}
-          ref="wrappedInstance"
-        />
-      );
-    }
+    return hoistStatics(ReduxFalcor, WrappedComponent);
   }
-
-  ReduxFalcor.displayName = `ReduxFalcor(${getDisplayName(WrappedComponent)})`;
-  ReduxFalcor.WrappedComponent = WrappedComponent;
-
-  ReduxFalcor.propTypes = {
-    falcorStore: PropTypes.object,
-    falcor: PropTypes.object,
-  };
-
-  ReduxFalcor.contextTypes = {
-    falcorStore: PropTypes.object.isRequired,
-    falcor: PropTypes.object.isRequired,
-  };
-
-  return hoistStatics(ReduxFalcor, WrappedComponent);
 }

--- a/src/components/reduxFalcor.js
+++ b/src/components/reduxFalcor.js
@@ -6,8 +6,6 @@ function getDisplayName(WrappedComponent) {
   return WrappedComponent.displayName || WrappedComponent.name || 'Component';
 }
 
-function noop() {}
-
 export default function reduxFalcor() {
 
   return function wrapWithFalcor (WrappedComponent) {
@@ -26,44 +24,9 @@ export default function reduxFalcor() {
         );
       }
 
-      componentDidMount() {
-        this.trySubscribe();
-      }
-
-      componentWillUnmount() {
-        this.tryUnsubscribe();
-      }
-
-      trySubscribe() {
-        if (!this.unsubscribe) {
-          this.unsubscribe = this.falcorStore.subscribe(::this.handleChange);
-          this.handleChange();
-        }
-      }
-
-      handleChange() {
-        const { wrappedInstance } = this.refs;
-
-        if (!this.unsubscribe) return;
-        if (!(typeof wrappedInstance.fetchFalcorDeps === 'function')) return;
-
-        wrappedInstance.fetchFalcorDeps().then(noop);
-      }
-
-      tryUnsubscribe() {
-        if (this.unsubscribe) {
-          this.unsubscribe();
-          this.unsubscribe = null;
-        }
-      }
-
       render() {
         return (
-          <WrappedComponent
-            {...this.props}
-            falcor={this.falcor}
-            ref="wrappedInstance"
-          />
+          <WrappedComponent {...this.props} falcor={this.falcor}/>
         );
       }
     }
@@ -73,12 +36,12 @@ export default function reduxFalcor() {
 
     ReduxFalcor.propTypes = {
       falcorStore: PropTypes.object,
-      falcor: PropTypes.object,
+      falcor: PropTypes.object
     };
 
     ReduxFalcor.contextTypes = {
       falcorStore: PropTypes.object.isRequired,
-      falcor: PropTypes.object.isRequired,
+      falcor: PropTypes.object.isRequired
     };
 
     return hoistStatics(ReduxFalcor, WrappedComponent);

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
-export { default as reducer } from './components/duck';
+export { default as reducer, updateFalcorCache } from './components/duck';
 export { default as FalcorProvider } from './components/FalcorProvider';
 export { default as reduxFalcor } from './components/reduxFalcor';


### PR DESCRIPTION
This PR consist of 3 changes which should ease the integration with redux-falcor (+ react) by reading the data from the falcor cache:

1. `reduxFalcor` is higher order component which returns a wrapping function instead of the component itself, this matches the common interface know from `react-redux` and allows better composition (e.g. via decorators)
2. `fetchFalcorDeps` got removed as it merely subscribes after `componentDidMount` and could be defined manually if required, moreover it emphasize the idea of using independent fetch approaches with universal support
3. `updateFalcorCache` is the update action which is now exported to set the data directly

Checkout the updated example to for more details.