### PR TITLE
Resolves Owner/Parent context issue with react 0.13

### DIFF
--- a/src/components/FalcorProvider.js
+++ b/src/components/FalcorProvider.js
@@ -63,7 +63,8 @@ export default class FalcorProvider extends Component {
   }
 
   render() {
-    const { children } = this.props;
-    return Children.only(children);
+    let {children} = this.props
+    children = children()
+    return children
   }
 }


### PR DESCRIPTION
Instead of expecting a React element the component will accept an anonymous function that return a React element. This is a workaround for context issues in React 0.13 and is not needed in React 14

Ref: https://medium.com/@skwee357/the-land-of-undocumented-react-js-the-context-99b3f931ff73#.yzdq1sitm