### PR TITLE
Chore: Remove use of expand cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "homepage": "https://github.com/ekosz/redux-falcor#readme",
   "dependencies": {
     "deepmerge": "^0.2.10",
-    "falcor-expand-cache": "^0.0.3",
     "falcor-json-graph": "^2.0.0",
     "hoist-non-react-statics": "^1.0.3",
     "invariant": "^2.2.0",

--- a/src/components/FalcorProvider.js
+++ b/src/components/FalcorProvider.js
@@ -1,5 +1,4 @@
 import { Component, PropTypes, Children } from 'react';
-import expandCache from 'falcor-expand-cache';
 
 import createStore from './createStore';
 
@@ -20,7 +19,7 @@ function debounce(func, wait) {
 function attachOnChange(falcor, store) {
   // TODO: Throttle requests here
   const handler = debounce(() => {
-    store.trigger(expandCache(falcor.getCache()));
+    store.trigger(falcor.getCache());
   }, 50);
 
   const root = falcor._root;


### PR DESCRIPTION
Since falcor v0.1.17 the getCache() function returns a fully unboxed object tree (https://github.com/Netflix/falcor/blob/v0.1.17/lib/get/getCache.js), this caused errors in expand cache. 