### PR TITLE
Remove usage of deprecated React.PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "falcor-json-graph": "^2.0.0",
     "hoist-non-react-statics": "^1.0.3",
     "invariant": "^2.2.0",
+    "prop-types": "^15.5.10",
     "tiny-uuid": "^1.0.0"
   },
   "peerDependencies": {

--- a/src/components/FalcorProvider.js
+++ b/src/components/FalcorProvider.js
@@ -1,4 +1,5 @@
-import { Component, PropTypes, Children } from 'react';
+import { Component, Children } from 'react';
+import PropTypes from 'prop-types';
 import expandCache from 'falcor-expand-cache';
 
 import createStore from './createStore';

--- a/src/components/reduxFalcor.js
+++ b/src/components/reduxFalcor.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import invariant from 'invariant';
 import hoistStatics from 'hoist-non-react-statics';
 


### PR DESCRIPTION
I'm seeing deprecation warnings from redux-falcor:

```
Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs
```

This PR modifies 2 components to use the `prop-types` module from NPM instead of `React.PropTypes`.